### PR TITLE
Remove unnecessary Sass pipe, and remove Sass syntax configuration

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -13,11 +13,8 @@ module.exports = {
     dest: dest + '/assets/'
   },
   sass: {
-    src: src + "/sass/**/*.{sass,scss}",
-    dest: dest + '/css/',
-    settings: {
-      indentedSyntax: true,
-    }
+    src: src + "/sass/**/*.scss",
+    dest: dest + '/css/'
   },
   html: {
     src: src + "/templates/*.html",

--- a/gulp/tasks/sass.js
+++ b/gulp/tasks/sass.js
@@ -7,13 +7,11 @@ var handleErrors = require('../util/handleErrors');
 var autoprefixer = require('gulp-autoprefixer');
 var config = require('../config').sass;
 
+
 gulp.task('sass', function () {
   return gulp.src(config.src)
     .pipe(sass({
       includePaths: require('node-neat').includePaths
-    }))
-    .pipe(sass({
-      includePaths: require('node-bourbon').includePaths
     }))
 
     .pipe(sourcemaps.init())


### PR DESCRIPTION
The second `.pipe(sass(...)` is unnecessary for two reasons: 1) Sass should not be chained to itself, you should not pipe Sass back to itself, and 2) because the node-neat `includePaths` array already includes Bourbon's `includePaths`.

I have had issues with mixing the two Sass syntaxes, but I had thought it was fixed in a recent version of node-sass. Since you aren't using the white-space syntax, just delete that configuration.
